### PR TITLE
Add a space to "is not a valid \"miz\" command."

### DIFF
--- a/assets/os/miz
+++ b/assets/os/miz
@@ -114,5 +114,5 @@ local firstArgSheet = {
 if firstArgSheet[arg[1]] then
 	firstArgSheet[arg[1]]()
 else
-	frontend_IO.err(arg[1] .. "is not a valid \"miz\" command.")
+	frontend_IO.err(arg[1] .. " is not a valid \"miz\" command.")
 end


### PR DESCRIPTION
Changes "is not a valid \"miz\" command." to " is not a valid \"miz\" command." The former led to "is" being concatenated to an invalid command in an error message.